### PR TITLE
Token exchange call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <fhir.version>3.0.0</fhir.version>
     <drools.version>7.28.0.Final</drools.version>
-    <cactus-common.version>0.0.5.3</cactus-common.version>
+    <cactus-common.version>0.0.5.4</cactus-common.version>
   </properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <fhir.version>3.0.0</fhir.version>
     <drools.version>7.28.0.Final</drools.version>
-    <cactus-common.version>0.0.5.2</cactus-common.version>
+    <cactus-common.version>0.0.5.3</cactus-common.version>
   </properties>
 
 	<repositories>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,12 @@ service.name=cdss
 
 # Security
 cactus.jwt.secret=local_only_not_so_secret
+cactus.auth.server=http://localhost:8083/auth
+cactus.ems.fhir.server=http://localhost:8083/fhir
 
 sqs.audit.queue=http://localhost:8089/sqs
+
+cactus.servers=${cactus.ems.fhir.server},${fhir.server}
 
 # Spring
 # `dev` profile must be overridden in production with `default` or more relevant profiles


### PR DESCRIPTION
Bumped the `cactus.common` version and added properties to indicate the following:
- the EMS as an auth server
- the EMS as a CACTUS service
- the list of known CACTUS services.

Depends on UECIT/cactus-common#6 being merged in.