### PR TITLE
Audit-saving fixes

### DIFF
--- a/src/main/java/uk/nhs/cdss/audit/AuditServerFilter.java
+++ b/src/main/java/uk/nhs/cdss/audit/AuditServerFilter.java
@@ -53,7 +53,6 @@ public class AuditServerFilter extends OncePerRequestFilter {
 
     try {
       filterChain.doFilter(requestWrapper, responseWrapper);
-      responseWrapper.copyBodyToResponse();
     } finally {
       var content = responseWrapper.getContentAsByteArray();
       responseWrapper.copyBodyToResponse();

--- a/src/main/java/uk/nhs/cdss/audit/AuditServerFilter.java
+++ b/src/main/java/uk/nhs/cdss/audit/AuditServerFilter.java
@@ -53,13 +53,16 @@ public class AuditServerFilter extends OncePerRequestFilter {
 
     try {
       filterChain.doFilter(requestWrapper, responseWrapper);
+      responseWrapper.copyBodyToResponse();
     } finally {
+      var content = responseWrapper.getContentAsByteArray();
+      responseWrapper.copyBodyToResponse();
+
       AuditSession auditSession = auditService
           .completeAuditSession(HttpRequest.from(requestWrapper),
-              HttpResponse.from(responseWrapper));
+              HttpResponse.from(responseWrapper, content));
 
       auditSender.sendAudit(auditSession);
-      responseWrapper.copyBodyToResponse();
     }
   }
 }

--- a/src/main/java/uk/nhs/cdss/audit/AuditService.java
+++ b/src/main/java/uk/nhs/cdss/audit/AuditService.java
@@ -117,7 +117,7 @@ public class AuditService {
 
       session.setRequestBody(exchangeHelper.getBodyString(request, request.getUri()));
       session.setResponseStatus(String.valueOf(response.getStatus()));
-      session.setResponseHeaders(exchangeHelper.getHeadersString(request));
+      session.setResponseHeaders(exchangeHelper.getHeadersString(response));
       session.setResponseBody(exchangeHelper.getBodyString(response, session.getRequestUrl()));
     } finally {
       auditThreadStore.removeCurrentSession();

--- a/src/main/java/uk/nhs/cdss/audit/HttpExchangeHelper.java
+++ b/src/main/java/uk/nhs/cdss/audit/HttpExchangeHelper.java
@@ -58,7 +58,6 @@ public class HttpExchangeHelper {
     var getAsGzip = getHeader(exchange, HttpHeaders.CONTENT_ENCODING)
         .map(contentEncoding -> gzipDecoder.decode(body, path, contentEncoding));
 
-    // TODO: gzip encoding and binary/non-text responses aren't mutually exclusive
     return getAsGzip
         .or(() -> getAsText)
         .orElseGet(() -> Base64.getEncoder().encodeToString(body));

--- a/src/main/java/uk/nhs/cdss/audit/HttpExchangeHelper.java
+++ b/src/main/java/uk/nhs/cdss/audit/HttpExchangeHelper.java
@@ -58,8 +58,9 @@ public class HttpExchangeHelper {
     var getAsGzip = getHeader(exchange, HttpHeaders.CONTENT_ENCODING)
         .map(contentEncoding -> gzipDecoder.decode(body, path, contentEncoding));
 
-    return getAsText
-        .or(() -> getAsGzip)
+    // TODO: gzip encoding and binary/non-text responses aren't mutually exclusive
+    return getAsGzip
+        .or(() -> getAsText)
         .orElseGet(() -> Base64.getEncoder().encodeToString(body));
   }
 

--- a/src/main/java/uk/nhs/cdss/audit/model/HttpResponse.java
+++ b/src/main/java/uk/nhs/cdss/audit/model/HttpResponse.java
@@ -38,7 +38,7 @@ public class HttpResponse implements HttpExchange {
     }
   }
 
-  public static HttpResponse from(ContentCachingResponseWrapper responseWrapper) {
+  public static HttpResponse from(ContentCachingResponseWrapper responseWrapper, byte[] content) {
     Map<String, List<String>> headers = responseWrapper.getHeaderNames().stream()
         .collect(toMap(
             identity(),
@@ -48,7 +48,7 @@ public class HttpResponse implements HttpExchange {
     return HttpResponse.builder()
         .headers(headers)
         .status(responseWrapper.getStatus())
-        .body(responseWrapper.getContentAsByteArray())
+        .body(content)
         .build();
   }
 

--- a/src/test/java/uk/nhs/cdss/audit/AuditServiceTest.java
+++ b/src/test/java/uk/nhs/cdss/audit/AuditServiceTest.java
@@ -227,7 +227,7 @@ public class AuditServiceTest {
         .thenReturn("test body returned");
     when(mockExchangeHelper.getBodyString(testResponse, "/testBodyPath"))
         .thenReturn("test response body returned");
-    when(mockExchangeHelper.getHeadersString(testRequest))
+    when(mockExchangeHelper.getHeadersString(testResponse))
         .thenReturn("test headers");
 
     AuditSession returned = auditService.completeAuditSession(testRequest, testResponse);


### PR DESCRIPTION
Show all audit headers for incoming requests, decode gzip bodies (more) correctly, show the appropriate response headers instead of always the request headers.