### PR TITLE
Add missing answers to NextQuestion clause

### DIFF
--- a/src/main/resources/drools/palpitations2.drl
+++ b/src/main/resources/drools/palpitations2.drl
@@ -443,10 +443,9 @@ then
     insert( new OutcomeAnswerCondition("notSyncope48hrs", "palpitations2.hasPalpitations", "q", Arrays.asList("No", "Unsure") ));
 
     //  If last experienced more than 48 hours
-    insert( new NextQuestion("palpitations2.syncope", "palpitations2.lastExperienced", "q3", Arrays.asList("Yes")));
+    insert( new NextQuestion("palpitations2.syncope", "palpitations2.lastExperienced", "q3", Arrays.asList("Yes", "No", "Unsure")));
     insert( new AnswerAssertion("palpitations2.lastExperienced", "q3", "Yes", codeDirectory.get("lastExperiencedMoreThan48"), true));
-    insert( new AnswerAssertion("palpitations2.lastExperienced", "q3", "No", codeDirectory.get("lastExperiencedMoreThan48"), true));
-    insert( new AnswerAssertion("palpitations2.lastExperienced", "q3", "Unsure", codeDirectory.get("lastExperiencedMoreThan48"), true));
+    insert( new AnswerAssertion("palpitations2.lastExperienced", "q3", "No", codeDirectory.get("lastExperiencedMoreThan48"), false));
     insert( gpArrhythmia("syncopeOver48hrs", "PT72h", "PT48h"));
     insert( new OutcomeAnswerCondition("syncopeOver48hrs", "palpitations2.syncope", "q", Arrays.asList("Yes", "Unsure") ));
     insert( new OutcomeAnswerCondition("syncopeOver48hrs", "palpitations2.lastExperienced", "q3", Arrays.asList("Yes", "No", "Unsure") ));

--- a/src/test/java/uk/nhs/cdss/engine/Palpitations2Test.java
+++ b/src/test/java/uk/nhs/cdss/engine/Palpitations2Test.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
 import org.junit.Test;
 import uk.nhs.cdss.exception.ServiceDefinitionException;
 
@@ -33,6 +34,18 @@ public class Palpitations2Test extends BaseDroolsCDSEngineTest {
     evaluate();
 
     assertEquals("ed-arrhythmia-emergency", output.getOutcome().getReferralRequest().getId());
+  }
+
+  @Test
+  public void regression_lastExperienced_moreThan48hours_no() throws ServiceDefinitionException {
+    // CDSCT-261
+    addAgeAssertion("1900-12-25");
+    answerQuestion("hasPalpitations", "q", "No");
+    answerQuestion("lastExperienced", "q3", "No");
+
+    evaluate();
+
+    assertEquals(List.of("palpitations2.syncope"), output.getQuestionnaireIds());
   }
 
   @Test


### PR DESCRIPTION
The repeated birthdate question loop was caused by the question flow logic only handling one of the three possible answers to the 'over 48 hours' question.