### PR TITLE
return empty list if no input data is provided instead of throwing

### DIFF
--- a/src/main/java/uk/nhs/cdss/component/ParameterResourceResolver.java
+++ b/src/main/java/uk/nhs/cdss/component/ParameterResourceResolver.java
@@ -1,5 +1,6 @@
 package uk.nhs.cdss.component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -8,6 +9,7 @@ import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 
 @Component
 @RequiredArgsConstructor
@@ -16,6 +18,10 @@ public class ParameterResourceResolver {
   private final ResourceLocator resourceLocator;
 
   public List<Resource> resolve(List<ParametersParameterComponent> paramComponents) {
+    if (ObjectUtils.isEmpty(paramComponents)) {
+      return Collections.emptyList();
+    }
+
     Stream<Resource> contained = paramComponents.stream()
         .filter(ParametersParameterComponent::hasResource)
         .map(ParametersParameterComponent::getResource);

--- a/src/test/java/uk/nhs/cdss/component/ParameterResourceResolverTest.java
+++ b/src/test/java/uk/nhs/cdss/component/ParameterResourceResolverTest.java
@@ -2,6 +2,7 @@ package uk.nhs.cdss.component;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -95,5 +96,13 @@ public class ParameterResourceResolverTest {
     assertThat(resolved, containsInAnyOrder(patient, obs));
     verify(resourceLocator).locate(obsRef);
     verifyNoMoreInteractions(resourceLocator);
+  }
+
+  @Test
+  public void resolvesNullParameters() {
+    List<Resource> resolved = resourceResolver.resolve(null);
+
+    assertThat(resolved, empty());
+    verifyZeroInteractions(resourceLocator);
   }
 }


### PR DESCRIPTION
Just a small change that means if the CDSS doesn't receive inputData as a parameter it won't die. Whilst our EMS will always send the initial 2 observations (which is why we haven't seen this before), a suppliers EMS may not have an 'initial' state.